### PR TITLE
frame counter; reduce unnecessary processing

### DIFF
--- a/src/keras_video/generator.py
+++ b/src/keras_video/generator.py
@@ -191,38 +191,38 @@ class VideoFrameGenerator(Sequence):
 
             if video not in self.__frame_cache:
                 cap = cv.VideoCapture(video)
+                total_frames = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+                frame_step = floor(total_frames/nbframe/2)
                 frames = []
+                frame_i = 0
                 while True:
+                    
                     grabbed, frame = cap.read()
                     if not grabbed:
                         # end of video
                         break
+                    
+                    frame_i += 1
+                    if frame_i % frame_step == 0:
+                        
+                        # resize
+                        frame = cv.resize(frame, shape)
 
-                    # resize
-                    frame = cv.resize(frame, shape)
+                        # use RGB or Grayscale ?
+                        if self.nb_channel == 3:
+                            frame = cv.cvtColor(frame, cv.COLOR_BGR2RGB)
+                        else:
+                            frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
 
-                    # use RGB or Grayscale ?
-                    if self.nb_channel == 3:
-                        frame = cv.cvtColor(frame, cv.COLOR_BGR2RGB)
-                    else:
-                        frame = cv.cvtColor(frame, cv.COLOR_RGB2GRAY)
+                        # to np
+                        frame = img_to_array(frame) * self.rescale
 
-                    # to np
-                    frame = img_to_array(
-                        frame) * self.rescale
-
-                    # keep frame
-                    frames.append(frame)
-
-                # Add 2 frames to drop first and last frame
-                jump = len(frames)//(nbframe+2)
-
-                # get only some images
-                try:
-                    frames = frames[jump::jump][:nbframe]
-                except Exception as exception:
-                    print(video)
-                    raise exception
+                        # keep frame
+                        frames.append(frame)
+                        
+                        # Break once the appropriate number of frames is collected
+                        if len(frames) == nbframe:
+                            break
 
                 # add to frame cache to not read from disk later
                 if self.use_frame_cache:


### PR DESCRIPTION
Instead of reading, resizing, converting, and appending every single frame in the video, this code maintains a counter and frame step interval to selectively process only frames that are necessary in (total_frames/frame_step/2) intervals. This reduces the overall processing time and splits the frame selection in relatively equal intervals across the video.