### PR TITLE
generator: applies standardization function from ImageDataGenerator

### DIFF
--- a/src/keras_video/generator.py
+++ b/src/keras_video/generator.py
@@ -357,6 +357,7 @@ class VideoFrameGenerator(Sequence):
             if transformation is not None:
                 frames = [self.transformation.apply_transform(
                     frame, transformation) for frame in frames]
+                frames = [self.transformation.standardize(frame) for frame in frames]
 
             # add the sequence in batch
             images.append(frames)


### PR DESCRIPTION
In case `samplewise_center` or `samplewise_std_normalization` are set to `True` in the `ImageDataGenerator`, a `standardization()` call applies these functions.
Otherwise, the aforementioned parameters are ignored.