### PR TITLE
Sliding frame generator crash if frame video <  self.nbframe

### DIFF
--- a/src/keras_video/sliding.py
+++ b/src/keras_video/sliding.py
@@ -80,7 +80,7 @@ class SlidingFrameGenerator(VideoFrameGenerator):
             stop_at = int(seqtime - self.nbframe)
             step = np.ceil(seqtime / self.nbframe).astype(np.int) - 1
             i = 0
-            while stop_at > 0 i <= frame_count - stop_at: # modified condition to ignore short video
+            while stop_at > 0 and i <= frame_count - stop_at: # modified condition to ignore short video
                 self.vid_info.append(
                     {
                         "id": count,

--- a/src/keras_video/sliding.py
+++ b/src/keras_video/sliding.py
@@ -80,7 +80,7 @@ class SlidingFrameGenerator(VideoFrameGenerator):
             stop_at = int(seqtime - self.nbframe)
             step = np.ceil(seqtime / self.nbframe).astype(np.int) - 1
             i = 0
-            while i <= frame_count - stop_at:
+            while stop_at > 0 i <= frame_count - stop_at: # modified condition to ignore short video
                 self.vid_info.append(
                     {
                         "id": count,


### PR DESCRIPTION
Hi i am new on github and i don't know if this is the good way to do that.
I use your code for my deep learning these at paris8 university

I propose to change the while condition for "__init_length" method adding "stop_at > 0 and your base condition"
That allowed to ignore short video instead of crash on ligne 89:
"frames": np.arange(i, i + stop_at)[::step][: self.nbframe]  -> ValueError : slice step cannot be zero
in case of video frame < self.nbframe

seqtime = int(frame_count)
stop_at = int(seqtime - self.nbframe) -> negative stop_at
