### PR TITLE
Update slidding to take in count time_sequence param

### DIFF
--- a/src/keras_video/generator.py
+++ b/src/keras_video/generator.py
@@ -391,16 +391,17 @@ class VideoFrameGenerator(Sequence):  # pylint: disable=too-many-instance-attrib
         return classname
 
     def _get_frames(
-        self, video, nbframe, shape, force_no_headers=False
+        self, video, nbframe, shape, seq_time=0, force_no_headers=False
     ) -> Optional[Iterable]:
         cap = cv.VideoCapture(video)
         total_frames = self.count_frames(cap, video, force_no_headers)
+        fps = cap.get(cv.CAP_PROP_FPS)
         orig_total = total_frames
 
         if total_frames % 2 != 0:
             total_frames += 1
 
-        frame_step = floor(total_frames / (nbframe - 1))
+        frame_step = floor(total_frames / (nbframe - 1)) if seq_time ==0 else floor((seq_time * fps) / (nbframe - 1))
         # TODO: fix that, a tiny video can have a frame_step that is
         # under 1
         frame_step = max(1, frame_step)

--- a/src/keras_video/sliding.py
+++ b/src/keras_video/sliding.py
@@ -77,6 +77,9 @@ class SlidingFrameGenerator(VideoFrameGenerator):
             else:
                 seqtime = int(frame_count)
 
+            # add an asssert to check if nbframe is possible in sequence_time
+            assert self.nbframe < seqtime, "ERROR nbframe > sequence_time change parameter and restart !"
+            
             stop_at = int(seqtime - self.nbframe)
             step = np.ceil(seqtime / self.nbframe).astype(np.int) - 1
             i = 0

--- a/src/keras_video/sliding.py
+++ b/src/keras_video/sliding.py
@@ -175,7 +175,7 @@ class SlidingFrameGenerator(VideoFrameGenerator):
 
             video_id = vid["id"]
             if video_id not in self.__frame_cache:
-                frames: Iterable = self._get_frames(video, nbframe, shape, self.sequence_time)
+                frames: Iterable = self._get_frames(video, nbframe, shape, self.sequence_time if self.sequence_time != None else 0)
             else:
                 frames: Iterable = self.__frame_cache[video_id]
 

--- a/src/keras_video/sliding.py
+++ b/src/keras_video/sliding.py
@@ -175,7 +175,7 @@ class SlidingFrameGenerator(VideoFrameGenerator):
 
             video_id = vid["id"]
             if video_id not in self.__frame_cache:
-                frames: Iterable = self._get_frames(video, nbframe, shape)
+                frames: Iterable = self._get_frames(video, nbframe, shape, self.sequence_time)
             else:
                 frames: Iterable = self.__frame_cache[video_id]
 


### PR DESCRIPTION
Im not an python OOP expert and i am some tired but i think i have correct the bug reported
[SlidingFrameGenerator] Sequence_time not working #32

I am new on github an i don't know the procedure to propose a bug solution

It think this solution need to be test an other time and is not the best solution
I had a ternary to send to the _get_frames  method the sequence_time or 0 if is none

I had some correct to on the generator file to add this optionnal parameter and calcul the new step using all video is the param is none or using juste the fixed sequence