### PR TITLE
UPDATE Sliding.py depreciated built in numpy int alias

### DIFF
--- a/src/keras_video/sliding.py
+++ b/src/keras_video/sliding.py
@@ -78,7 +78,7 @@ class SlidingFrameGenerator(VideoFrameGenerator):
                 seqtime = int(frame_count)
 
             stop_at = int(seqtime - self.nbframe)
-            step = np.ceil(seqtime / self.nbframe).astype(np.int) - 1
+            step = np.ceil(seqtime / self.nbframe).astype(int) - 1
             i = 0
             while stop_at > 0 and i <= frame_count - stop_at: # modified condition to ignore short video
                 self.vid_info.append(


### PR DESCRIPTION
 addressed a NumPy deprecation warning that arose due to the use of np.int. As of NumPy 1.20, np.int is a deprecated alias for the built-in int. To prevent potential issues and align with the recommended practices, I replaced instances of np.int with the built-in int. This change ensures compatibility with future releases of NumPy.

For users reviewing this code, please be aware that the use of np.int has been deprecated, and it is advisable to use int directly. If specifying precision is necessary, consider using np.int64 or np.int32 as appropriate.